### PR TITLE
Refactor Firebase error mapping for consistency

### DIFF
--- a/backend/src/utils/FirebaseErrorMapper.js
+++ b/backend/src/utils/FirebaseErrorMapper.js
@@ -1,20 +1,20 @@
 import { ApiError } from "./ApiError.js";
 
-export const mapAdminError = (e, defaultMessage = 'Error with Firebase Auth') => {
+export const mapAdminError = (e) => {
   switch (e.code) {
     case 'auth/email-already-exists':
-      return new ApiError(409, 'The email address is already in use by another account.', [], e.stack);
+      return new ApiError(409, e.message, [{code: e.code}], e.stack);
     case 'auth/invalid-password':
-      return new ApiError(400, 'Invalid password (must be at least 6 characters).', [], e.stack);
+      return new ApiError(400, e.message, [{code: e.code}], e.stack);
     case 'auth/invalid-email':
-      return new ApiError(400, 'Invalid email address.', [], e.stack);
+      return new ApiError(400, e.message, [{code: e.code}], e.stack);
     case 'auth/operation-not-allowed':
-      return new ApiError(503, 'Email/password sign-in is disabled in Firebase settings.', [], e.stack);
+      return new ApiError(503, e.message, [{code: e.code}], e.stack);
     case 'auth/uid-already-exists':
-      return new ApiError(409, 'A user with this UID already exists.', [], e.stack);
+      return new ApiError(409, e.message, [{code: e.code}], e.stack);
     case 'auth/configuration-not-found':
-        return new ApiError(400, 'There is no configuration corresponding to the provided identifier.', [e.code], e.stack)
+        return new ApiError(400, e.message, [{code: e.code}], e.stack)
     default:
-      return new ApiError(500, defaultMessage, [{ code: e.code, message: e.message }], e.stack);
+      return new ApiError(500, e.message, [{ code: e.code }], e.stack);
   }
 };


### PR DESCRIPTION
Standardizes error responses in mapAdminError to use the error's message and code consistently. Removes the defaultMessage parameter and ensures all mapped errors include the code in the details array.